### PR TITLE
Update eddsa to 0.2.0

### DIFF
--- a/ECC-25519-Java/build.gradle
+++ b/ECC-25519-Java/build.gradle
@@ -8,7 +8,7 @@ repositories {
 }
 
 dependencies {
-    compile 'net.i2p.crypto:eddsa:0.1.0'
+    compile 'net.i2p.crypto:eddsa:0.2.0'
 
     testCompile 'junit:junit:4.11'
 }


### PR DESCRIPTION
There is a new version of eddsa available which includes support for the new OIDs from [draft-ietf-curdle-pkix-07](https://tools.ietf.org/html/draft-ietf-curdle-pkix-07).